### PR TITLE
Added Types for typescript support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@
 /es
 /lib
 /node_modules
+/types
 /umd
 npm-debug.log*

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "[![Travis][build-badge]][build] [![npm package][npm-badge]][npm] [![Coveralls][coveralls-badge]][coveralls]",
   "main": "lib/index.js",
   "module": "es/index.js",
+  "types": "types/index.d.ts",
   "files": [
     "src",
     "es",
@@ -11,12 +12,13 @@
     "umd"
   ],
   "scripts": {
-    "build": "nwb build-web-module",
+    "build": "nwb build-web-module && create-types",
     "clean": "nwb clean-module",
     "prepublishOnly": "npm run build",
     "test": "nwb test",
     "test:coverage": "nwb test --coverage",
-    "test:watch": "nwb test --server"
+    "test:watch": "nwb test --server",
+    "create-types": "npx tsc -p ./ts-config.json"
   },
   "dependencies": {},
   "devDependencies": {

--- a/ts-config.json
+++ b/ts-config.json
@@ -1,0 +1,12 @@
+{
+    "include": [
+        "src/**/*"
+    ],
+    "compilerOptions": {
+        "allowJs": true,
+        "declaration": true,
+        "emitDeclarationOnly": true,
+        "outDir": "types",
+        "declarationMap": true
+    }
+}


### PR DESCRIPTION
Running the build script should now also create the .d.ts and .d.ts.map file.
When installing this package in a typescript project, the types should be available without any further adjustments.